### PR TITLE
change setup-python@v5

### DIFF
--- a/.github/workflows/python-cron.yml
+++ b/.github/workflows/python-cron.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 파이썬 셋업
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4.